### PR TITLE
Pass initialized object for policy parameters

### DIFF
--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -69,7 +69,7 @@ class RalfMapper:
             enumerate(map(list, divide(num_replicas, source_keys)))
         )
 
-        self.key_selection_policy = key_selection_policy_cls()
+        self.key_selection_policy = key_selection_policy_cls 
         self.model_runtime_s = model_run_time_s
         for i in range(num_replicas):
             self.env.process(self.run(replica_id=i))

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -3,10 +3,10 @@ import itertools
 import random
 from dataclasses import dataclass
 from typing import Dict, List, Type
-from more_itertools.more import divide
 
 import simpy
 from more_itertools import chunked
+from more_itertools.more import divide
 
 from ralf.simulation.priority_queue import PerKeyPriorityQueue
 

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -69,7 +69,7 @@ class RalfMapper:
             enumerate(map(list, divide(num_replicas, source_keys)))
         )
 
-        self.key_selection_policy = key_selection_policy_cls 
+        self.key_selection_policy = key_selection_policy_cls
         self.model_runtime_s = model_run_time_s
         for i in range(num_replicas):
             self.env.process(self.run(replica_id=i))


### PR DESCRIPTION
Need to be able to pass in initialization inputs for key prioritization policies (e.g. weights file), so seems easier to pass in an initialized object. 