### PR TITLE
Round robin cross-key prioritization fix

### DIFF
--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -69,7 +69,7 @@ class RalfMapper:
             enumerate(map(list, divide(num_replicas, source_keys)))
         )
 
-        self.key_selection_policy = key_selection_policy_cls()
+        self.key_selection_policy = key_selection_policy_cls 
         self.model_runtime_s = model_run_time_s
         for i in range(num_replicas):
             self.env.process(self.run(replica_id=i))

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -3,10 +3,10 @@ import itertools
 import random
 from dataclasses import dataclass
 from typing import Dict, List, Type
-from more_itertools.more import divide
 
 import simpy
 from more_itertools import chunked
+from more_itertools.more import divide
 
 from ralf.simulation.priority_queue import PerKeyPriorityQueue
 

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -69,7 +69,7 @@ class RalfMapper:
             enumerate(map(list, divide(num_replicas, source_keys)))
         )
 
-        self.key_selection_policy = key_selection_policy_cls 
+        self.key_selection_policy = key_selection_policy_cls
         self.model_runtime_s = model_run_time_s
         for i in range(num_replicas):
             self.env.process(self.run(replica_id=i))

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -21,19 +21,24 @@ class CrossKeyLoadBalancer(abc.ABC):
 class RoundRobinLoadBalancer(CrossKeyLoadBalancer):
     """Simple policy that cycle through all the keys fairly"""
 
-    def __init__(self):
-        self.cur_key_set = set()
-        self.cur_key_iter = None
+    def __init__(self, num_replicas=1):
+        self.cur_key_iter = {}
+        self.cur_key_set = {}
+        for replica_id in range(num_replicas):
+            self.cur_key_set[replica_id] = set()
+            self.cur_key_iter[replica_id] = None
 
-    def choose(self, per_key_queues: Dict[KeyType, PerKeyPriorityQueue]) -> KeyType:
+    def choose(
+        self, per_key_queues: Dict[KeyType, PerKeyPriorityQueue], replica_id: int
+    ) -> KeyType:
         key_set = set(per_key_queues.keys())
-        if key_set != self.cur_key_set:
-            self.cur_key_set = key_set
-            self.cur_key_iter = itertools.cycle(key_set)
+        if key_set != self.cur_key_set[replica_id]:
+            self.cur_key_set[replica_id] = key_set
+            self.cur_key_iter[replica_id] = itertools.cycle(key_set)
 
-        key = next(self.cur_key_iter)
+        key = next(self.cur_key_iter[replica_id])
         while per_key_queues[key].size() == 0:
-            key = next(self.cur_key_iter)
+            key = next(self.cur_key_iter[replica_id])
         # TODO(simon): maybe do a "peak" here to trigger eviction policies
         return key
 
@@ -87,7 +92,9 @@ class RalfMapper:
             )
 
             # windows = yield self.source_queue.get()
-            chosen_key = self.key_selection_policy.choose(this_shard_source_queues)
+            chosen_key = self.key_selection_policy.choose(
+                this_shard_source_queues, replica_id
+            )
             windows = yield self.total_source_queues[chosen_key].get()
             print(
                 f"at time {self.env.now:.2f}, RalfMapper {replica_id} should work on {windows} (last timestamp)"

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -83,7 +83,9 @@ class RalfMapper:
         }
         while True:
 
-            yield simpy.AnyOf(self.env, [q.wait() for q in this_shard_source_queues.values()])
+            yield simpy.AnyOf(
+                self.env, [q.wait() for q in this_shard_source_queues.values()]
+            )
 
             # windows = yield self.source_queue.get()
             chosen_key = self.key_selection_policy.choose(this_shard_source_queues)

--- a/ralf/simulation/mapper.py
+++ b/ralf/simulation/mapper.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Type
 
 import simpy
-from more_itertools import chunked
 from more_itertools.more import divide
 
 from ralf.simulation.priority_queue import PerKeyPriorityQueue

--- a/ralf/simulation/priority_queue.py
+++ b/ralf/simulation/priority_queue.py
@@ -38,6 +38,10 @@ class PerKeyPriorityQueue(simpy.Store):
     def size(self):
         return len(self.items)
 
+    def clear(self): 
+        self.items.clear()
+        self.waiters.clear()
+
     def wait(self) -> simpy.Event:
         event = simpy.Event(self._env)
         if self.size() == 0:

--- a/ralf/simulation/priority_queue.py
+++ b/ralf/simulation/priority_queue.py
@@ -38,7 +38,7 @@ class PerKeyPriorityQueue(simpy.Store):
     def size(self):
         return len(self.items)
 
-    def clear(self): 
+    def clear(self):
         self.items.clear()
         self.waiters.clear()
 

--- a/ralf/simulation/source.py
+++ b/ralf/simulation/source.py
@@ -1,7 +1,7 @@
 import json
+import os
 from collections import defaultdict
 from typing import List, Optional
-import os
 
 import pandas as pd
 import simpy
@@ -31,7 +31,7 @@ class Source:
 
         if data_dir is not None:
             self.data = {}
-            for key in keys: 
+            for key in keys:
                 self.data[key] = []
                 data_file = os.path.join(data_dir, f"{key}.csv")
                 df = pd.read_csv(data_file)
@@ -39,7 +39,7 @@ class Source:
                     self.data[key].append(row.to_dict())
                 print("Read", len(self.data[key]), data_file)
 
-        for key in self.keys: 
+        for key in self.keys:
             assert len(self.data[key]) == len(self.data[self.keys[0]])
         self.ts_len = len(self.data[self.keys[0]])
 

--- a/ralf/simulation/source.py
+++ b/ralf/simulation/source.py
@@ -102,7 +102,9 @@ class JSONSource:
                 print(
                     f"Complete source ts: {self.index}/{len(self.data)}, env time: {self.env.now}/{self.total_run_time}"
                 )
-                open("optimal_plan.json", "w").write(json.dumps(self.optimal_plan))
+                open("/data/wooders/wikipedia/optimal_plan.json", "w").write(
+                    json.dumps(self.optimal_plan)
+                )
                 break
 
             # send for each key at timestep

--- a/ralf/simulation/source.py
+++ b/ralf/simulation/source.py
@@ -1,6 +1,7 @@
 import json
 from collections import defaultdict
 from typing import List, Optional
+import os
 
 import pandas as pd
 import simpy
@@ -15,8 +16,9 @@ class Source:
         records_per_sec_per_key: int,
         num_keys: int,
         next_queue: simpy.Store,
+        keys: List[int],
         total_run_time: Optional[float] = None,
-        data_file: Optional[str] = None,
+        data_dir: Optional[str] = None,
     ):
         self.env = env
         self.records_per_sec_per_key = records_per_sec_per_key
@@ -25,22 +27,31 @@ class Source:
         self.total_run_time = total_run_time
         self.data: Optional[List] = None
 
-        if data_file is not None:
-            print("Reading", data_file)
-            self.data = []
-            df = pd.read_csv(data_file)
-            for index, row in df.iterrows():
-                self.data.append(row.to_dict())
+        self.keys = list(keys)
+
+        if data_dir is not None:
+            self.data = {}
+            for key in keys: 
+                self.data[key] = []
+                data_file = os.path.join(data_dir, f"{key}.csv")
+                df = pd.read_csv(data_file)
+                for index, row in df.iterrows():
+                    self.data[key].append(row.to_dict())
+                print("Read", len(self.data[key]), data_file)
+
+        for key in self.keys: 
+            assert len(self.data[key]) == len(self.data[self.keys[0]])
+        self.ts_len = len(self.data[self.keys[0]])
 
         self.env.process(self.run())
 
     def run(self):
         record_id = 0
         while True:
-            if self.total_run_time and self.env.now > self.total_run_time:
+            if record_id >= self.ts_len or self.env.now > self.total_run_time:
                 break
 
-            for key in range(self.num_keys):
+            for key in self.keys:
                 # TODO: add sleep here instead?
                 if self.data is None:
                     yield self.next_queue.put(
@@ -52,7 +63,7 @@ class Source:
                             key=key,
                             seq_id=record_id,
                             processing_time=self.env.now,
-                            value=self.data[record_id]["value"],
+                            value=self.data[key][record_id]["value"],
                         )
                     )
             record_id += 1

--- a/ralf/simulation/window.py
+++ b/ralf/simulation/window.py
@@ -28,7 +28,6 @@ class WindowOperator:
         else:
             self.per_key_slide_size_dict = {}
 
-        print("WINDOW", self.per_key_slide_size_dict)
         self.source_queue = source_queue
         self.windows: DefaultDict[int, List[float]] = defaultdict(list)
         self.next_queues = next_queues
@@ -55,7 +54,6 @@ class WindowOperator:
                     self.per_key_slide_size_dict.get(str(item.key))
                     or self.global_slide_size
                 )
-                print("slide size", item.key, slide_size)
                 self.windows[item.key] = self.windows[item.key][slide_size:]
 
             # NOTE(simon): edit this timeout for "window process time"

--- a/ralf/simulation/window.py
+++ b/ralf/simulation/window.py
@@ -27,6 +27,8 @@ class WindowOperator:
             self.per_key_slide_size_dict = json.load(open(per_key_slide_size_path))
         else:
             self.per_key_slide_size_dict = {}
+
+        print("WINDOW", self.per_key_slide_size_dict)
         self.source_queue = source_queue
         self.windows: DefaultDict[int, List[float]] = defaultdict(list)
         self.next_queues = next_queues
@@ -53,6 +55,7 @@ class WindowOperator:
                     self.per_key_slide_size_dict.get(str(item.key))
                     or self.global_slide_size
                 )
+                print("slide size", item.key, slide_size)
                 self.windows[item.key] = self.windows[item.key][slide_size:]
 
             # NOTE(simon): edit this timeout for "window process time"


### PR DESCRIPTION
* Add wait to ralf mapper so that it's triggered on an event for *any* key 
* Add `clear()` to priority queue 
* Make sure round robin chooses a key that has events 
* Pass in pre-initialized `per_key_policy` for mappers'
* Add sharding to round-robin cross-key prioritization